### PR TITLE
properly set name on custom Errors

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,4 +1,5 @@
 {
   "-W014": true,
-  "globalstrict": true
+  "globalstrict": true,
+  "esnext": true
 }

--- a/errors.js
+++ b/errors.js
@@ -1,20 +1,20 @@
 /*global exports */
 'use strict';
-function UserNotFound(uid) {
-  this.message = 'User with user id ' + uid + ' not found.';
-  var err = new Error(this.message);
-  err.name = this.constructor.name;
-  this.stack = err.stack;
+class UserNotFound extends Error {
+  constructor(uid) {
+    super(`User with user id {uid} not found.`);
+    Error.captureStackTrace(this, this.constructor);
+    this.name = this.constructor.name;
+  }
 }
-UserNotFound.prototype = new Error();
 
-function UsernameNotAvailable(username) {
-  this.message = 'The username ' + username + ' is not available or already taken.';
-  var err = new Error(this.message);
-  err.name = this.constructor.name;
-  this.stack = err.stack;
+class UsernameNotAvailable extends Error {
+  constructor(username) {
+    super(`The username {username} is not available or already taken.`);
+    Error.captureStackTrace(this, this.constructor);
+    this.name = this.constructor.name;
+  }
 }
-UsernameNotAvailable.prototype = new Error();
 
 exports.UserNotFound = UserNotFound;
 exports.UsernameNotAvailable = UsernameNotAvailable;

--- a/test/errors.js
+++ b/test/errors.js
@@ -25,6 +25,10 @@ describe('errors', function () {
         var err = new UserError();
         expect(err.stack).to.contain(name);
       });
+      it('uses its name', function () {
+        var err = new UserError();
+        expect(err.name).to.equal(name);
+      });
     });
   });
 });


### PR DESCRIPTION
See also #1.

The `uses its argument in its message` test is still failing. It was already failing in master, in addition to other tests which are now passing.
